### PR TITLE
New button layout for dice input

### DIFF
--- a/dicerolls/screen.py
+++ b/dicerolls/screen.py
@@ -1,6 +1,6 @@
 import lvgl as lv
 from gui.screens.screen import Screen
-from gui.common import add_label, add_button_pair , add_button, HOR_RES
+from gui.common import add_label, add_button_pair, add_button
 from gui.decorators import on_release, cb_with_args
 
 from .const import *
@@ -21,33 +21,33 @@ class DiceRollsScreen(Screen):
 
         self.pips_1 = add_button("1", on_release(cb_with_args(self.set_value, DICE_ROLLED_1)), scr=self)
         self.pips_1.set_width(130)
-        self.pips_1.align(self.page, lv.ALIGN.OUT_LEFT_MID, 20, 20)
-        self.pips_1.set_x(100)
+        self.pips_1.set_height(100)
+        self.pips_1.align(self.page, lv.ALIGN.IN_TOP_LEFT, 20, 270)
 
         self.pips_2 = add_button("2", on_release(cb_with_args(self.set_value, DICE_ROLLED_2)), scr=self)
         self.pips_2.set_width(130)
-        self.pips_2.align(self.page, lv.ALIGN.OUT_RIGHT_MID, 20, 20)
-        self.pips_2.set_x(HOR_RES - 230)
+        self.pips_2.set_height(100)
+        self.pips_2.align(self.page, lv.ALIGN.IN_TOP_MID, 0, 270)
 
         self.pips_3 = add_button("3", on_release(cb_with_args(self.set_value, DICE_ROLLED_3)), scr=self)
         self.pips_3.set_width(130)
-        self.pips_3.align(self.page, lv.ALIGN.OUT_LEFT_MID, -20, 110)
-        self.pips_3.set_x(100)
+        self.pips_3.set_height(100)
+        self.pips_3.align(self.page, lv.ALIGN.IN_TOP_RIGHT, -20, 270)
 
-        self.pips_4 = add_button(u"4", on_release(cb_with_args(self.set_value, DICE_ROLLED_4)), scr=self)
+        self.pips_4 = add_button("4", on_release(cb_with_args(self.set_value, DICE_ROLLED_4)), scr=self)
         self.pips_4.set_width(130)
-        self.pips_4.align(self.page, lv.ALIGN.OUT_RIGHT_MID, 20, 110)
-        self.pips_4.set_x(HOR_RES - 230)
+        self.pips_4.set_height(100)
+        self.pips_4.align(self.page, lv.ALIGN.IN_BOTTOM_LEFT, 20, -110)
 
         self.pips_5 = add_button("5", on_release(cb_with_args(self.set_value, DICE_ROLLED_5)), scr=self)
         self.pips_5.set_width(130)
-        self.pips_5.align(self.page, lv.ALIGN.OUT_LEFT_MID, -20, 200)
-        self.pips_5.set_x(100)
+        self.pips_5.set_height(100)
+        self.pips_5.align(self.page, lv.ALIGN.IN_BOTTOM_MID, 0, -110)
 
         self.pips_6 = add_button("6", on_release(cb_with_args(self.set_value, DICE_ROLLED_6)), scr=self)
         self.pips_6.set_width(130)
-        self.pips_6.align(self.page, lv.ALIGN.OUT_RIGHT_MID, 20, 200)
-        self.pips_6.set_x(HOR_RES - 230)
+        self.pips_6.set_height(100)
+        self.pips_6.align(self.page, lv.ALIGN.IN_BOTTOM_RIGHT, -20, -110)
 
         (self.close_button, self.again_button) = add_button_pair(
             lv.SYMBOL.LEFT + " Back",


### PR DESCRIPTION
Dice input button layout that doesn't get pushed under main action button when the info section is larger.

<img width="301" alt="Screenshot 2023-02-27 at 18 03 10" src="https://user-images.githubusercontent.com/120567975/229273401-f5f130ce-8c98-43e3-b265-789dc7221806.png">
